### PR TITLE
Simplify code by removing redundant logic

### DIFF
--- a/count-tokens.js
+++ b/count-tokens.js
@@ -23,19 +23,14 @@ const processFile = async () => {
             const pdfData = await parser.getText();
             data = pdfData.text;
         } else if (extension === '.docx') {
-            const result = await mammoth.extractRawText({ path: filename });
-            data = result.value;
+            data = (await mammoth.extractRawText({ path: filename })).value;
         } else if (extension === '.csv') {
-            const fileContent = fs.readFileSync(filename, 'utf8');
-            const result = Papa.parse(fileContent);
-            data = result.data.map(row => row.join(' ')).join('\n');
+            data = Papa.parse(fs.readFileSync(filename, 'utf8')).data.map(row => row.join(' ')).join('\n');
         } else if (extension === '.xlsx') {
             const workbook = XLSX.readFile(filename);
             const sheetName = workbook.SheetNames[0];
             const worksheet = workbook.Sheets[sheetName];
             data = XLSX.utils.sheet_to_csv(worksheet);
-        } else if (extension === '.md') {
-            data = fs.readFileSync(filename, 'utf8');
         } else {
             data = fs.readFileSync(filename, 'utf8');
         }


### PR DESCRIPTION
## Summary
- Inline DOCX result variable to reduce from 2 lines to 1
- Inline CSV file reading and parsing to reduce from 3 lines to 1
- Remove duplicate `.md` case that had identical logic to default case

## Impact
- Reduces file from 52 to 47 lines (~9.6% reduction)
- Eliminates 3 intermediate variables
- Removes code duplication
- All functionality preserved

## Test plan
- [ ] Verify token counting works for PDF files
- [ ] Verify token counting works for DOCX files
- [ ] Verify token counting works for CSV files
- [ ] Verify token counting works for XLSX files
- [ ] Verify token counting works for Markdown files
- [ ] Verify token counting works for plain text files

🤖 Generated with [Claude Code](https://claude.com/claude-code)